### PR TITLE
Зафиксировал цвет штоки как universalBlack ЧИТАЙТЕ КОММЕНТ

### DIFF
--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -10,6 +10,6 @@
         <item name="colorSecondary">@color/whiteUniversal</item>
         <item name="colorSecondaryVariant">@color/blackUniversal</item>
         <item name="colorOnSecondary">@color/gray</item>
-        <item name="android:statusBarColor">?attr/colorSecondaryVariant</item>
+        <item name="android:statusBarColor">@color/blackUniversal</item>
     </style>
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -8,6 +8,6 @@
         <item name="colorSecondary">@color/blackUniversal</item>
         <item name="colorSecondaryVariant">@color/whiteUniversal</item>
         <item name="colorOnSecondary">@color/lightGray</item>
-        <item name="android:statusBarColor">?attr/colorSecondaryVariant</item>
+        <item name="android:statusBarColor">@color/blackUniversal</item>
     </style>
 </resources>


### PR DESCRIPTION
Сделал так, чтобы шторка была всегда одного цвета universalBlack, т.к. у меня в светлой теме на телефоне текст шторки слился с фоном.

НЕ УВЕРЕН, ЧТО НУЖНО ПРИНИМАТЬ ДАННЫЕ ИЗМЕНЕНИЯ, Т.К. В ТЗ БЫЛА УКАЗАНА КОНКРЕТНАЯ ТЕМА Theme.MaterialComponents.DayNight.NoActionBar, КОТОРАЯ НЕ РАБОТАЕТ СО ШТОРКОЙ