### PR TITLE
fix: layout Industry View

### DIFF
--- a/app/src/main/res/layout/industry_view.xml
+++ b/app/src/main/res/layout/industry_view.xml
@@ -9,9 +9,9 @@
     <TextView
         android:id="@+id/tvIndustryName"
         android:layout_width="0dp"
-        android:layout_height="60dp"
+        android:layout_height="48dp"
         android:layout_weight="11"
-        android:layout_marginVertical="8dp"
+        android:layout_marginVertical="6dp"
         style="@style/industry_item"
         android:maxLines="2"
         android:ellipsize="end"


### PR DESCRIPTION
android:layout_height="48dp" // было 60
android:layout_marginVertical="6dp" // был 8
Итого на вью приходилось 76dp, теперь - 60dp